### PR TITLE
Update to version 1000.0.0 in package.xml.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -7,7 +7,7 @@
 <package format="2">
   <name>librealsense2</name>
   <!-- The version tag needs to be updated with each new release of librealsense -->
-  <version>2.16.0</version>
+  <version>1000.0.0</version>
   <description>
   Library for capturing data from the Intel(R) RealSense(TM) SR300 and D400 cameras. This effort was initiated to better support researchers, creative coders, and app developers in domains such as robotics, virtual reality, and the internet of things. Several often-requested features of RealSense(TM); devices are implemented in this project, including multi-camera capture.
   </description>


### PR DESCRIPTION
# Change in this PR

Update the version number in package.xml.

# Background

- This change doesn't add any functional value.
- This change will be helpful for maintenance, when we decide to build this software with catkin.
  - I confirmed that when built by `catkin_make_isolated`, package.xml gets created in the install space.

  ```
  $ catkin_make_isolated -DCMAKE_BUILD_TYPE=Release --install
  $ cat `find install_isolated/ -iname package.xml` | grep -i version
  <?xml version="1.0"?>
    <!-- The version tag needs to be updated with each new release of librealsense -->
    <version>1000.0.0</version>
    <license>Apache License, Version 2.0</license>
  ```
- After all, this wouldn't hurt.

# Review items
- [x] Code review

# Post merge TODOs
- I'm thinking to re-create 1000.0.0 tag. There's no other change after 1000.0.0, so that should be ok hopefully.